### PR TITLE
ISO 8601 format is HH:MM:SS.mmmmmm or HH:MM:SS if milliseconds are zero

### DIFF
--- a/src/main/java/com/fatboyindustrial/gsonjodatime/LocalTimeConverter.java
+++ b/src/main/java/com/fatboyindustrial/gsonjodatime/LocalTimeConverter.java
@@ -34,8 +34,9 @@ import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.LocalTime;
-import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.lang.reflect.Type;
 
@@ -44,8 +45,11 @@ import java.lang.reflect.Type;
  */
 public class LocalTimeConverter implements JsonSerializer<LocalTime>, JsonDeserializer<LocalTime>
 {
-  /** Format specifier */
-  private static final String PATTERN = "HH:mm:ss.SSS";
+  /** Real ISO8601 Format specifier */
+  private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+          .append(ISODateTimeFormat.time().getPrinter(),
+                  ISODateTimeFormat.localTimeParser().getParser())
+          .toFormatter();
 
   /**
    * Gson invokes this call-back method during serialization when it encounters a field of the
@@ -63,8 +67,7 @@ public class LocalTimeConverter implements JsonSerializer<LocalTime>, JsonDeseri
   @Override
   public JsonElement serialize(LocalTime src, Type typeOfSrc, JsonSerializationContext context)
   {
-    final DateTimeFormatter fmt = DateTimeFormat.forPattern(PATTERN);
-    return new JsonPrimitive(fmt.print(src));
+    return new JsonPrimitive(src.toString(FORMATTER));
   }
 
   /**
@@ -91,7 +94,6 @@ public class LocalTimeConverter implements JsonSerializer<LocalTime>, JsonDeseri
       return null;
     }
 
-    final DateTimeFormatter fmt = DateTimeFormat.forPattern(PATTERN);
-    return fmt.parseLocalTime(json.getAsString());
+    return LocalTime.parse(json.getAsString(), FORMATTER);
   }
 }

--- a/src/test/java/com/fatboyindustrial/gsonjodatime/LocalTimeConverterTest.java
+++ b/src/test/java/com/fatboyindustrial/gsonjodatime/LocalTimeConverterTest.java
@@ -28,6 +28,9 @@ package com.fatboyindustrial.gsonjodatime;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.joda.time.LocalTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -49,6 +52,15 @@ public class LocalTimeConverterTest
     final LocalTime lt = new LocalTime();
 
     assertThat(gson.fromJson(gson.toJson(lt), LocalTime.class), is(lt));
+  }
+
+  @Test
+  public void test_timedelta_without_millis()
+  {
+    final Gson gson = Converters.registerLocalTime(new GsonBuilder()).create();
+    final LocalTime lt = new LocalTime(1,20,30);
+
+    assertThat(gson.fromJson("\"1:20:30\"", LocalTime.class), is(lt));
   }
 
   /**


### PR DESCRIPTION
Dear @gkopff ,

I stumbled across a problem in which my server (python django-rest) serializes a timedelta in ISO8601, using the following formats:

HH:MM:SS.mmmmmm or HH:MM:SS if milliseconds are zero (which is my case).

Initially it would make sense just to remove the milliseconds in the PATTERN string; however, I came up with a better solution that works for both scenarios (with or without milliseconds) using joda's own ISO Formatters.

Please review it, as it would undoubtedly benefit other Python/Android developers. 

Have a good one, cheers.

Thiago Pagonha.