### PR TITLE
Made the DateTimeConverter deserialize ISO 8601 strings without milliseconds value correctly.

### DIFF
--- a/src/main/java/com/fatboyindustrial/gsonjodatime/DateTimeConverter.java
+++ b/src/main/java/com/fatboyindustrial/gsonjodatime/DateTimeConverter.java
@@ -87,7 +87,7 @@ public class DateTimeConverter implements JsonSerializer<DateTime>, JsonDeserial
       return null;
     }
 
-    final DateTimeFormatter fmt = ISODateTimeFormat.dateTime();
+    final DateTimeFormatter fmt = ISODateTimeFormat.dateTimeParser();
     return fmt.parseDateTime(json.getAsString());
   }
 }

--- a/src/test/java/com/fatboyindustrial/gsonjodatime/DateTimeConverterTest.java
+++ b/src/test/java/com/fatboyindustrial/gsonjodatime/DateTimeConverterTest.java
@@ -78,7 +78,8 @@ public class DateTimeConverterTest
    * Tests that deserialising an ISO 8601 string with a milliseconds value works
    */
   @Test
-  public void testDeserializeWithMilliseconds() {
+  public void testDeserializeWithMilliseconds()
+  {
     final Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
     final String str = "\"2016-07-01T12:30:25.0Z\"";
     final DateTime expected = new DateTime(2016, 7, 1, 12, 30, 25,
@@ -91,7 +92,8 @@ public class DateTimeConverterTest
    * Tests that deserialising an ISO 8601 string without a milliseconds value works
    */
   @Test
-  public void testDeserializeWithoutMilliseconds() {
+  public void testDeserializeWithoutMilliseconds()
+  {
     final Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
     final String str = "\"2016-07-01T12:30:25Z\"";
     final DateTime expected = new DateTime(2016, 7, 1, 12, 30, 25,

--- a/src/test/java/com/fatboyindustrial/gsonjodatime/DateTimeConverterTest.java
+++ b/src/test/java/com/fatboyindustrial/gsonjodatime/DateTimeConverterTest.java
@@ -28,6 +28,7 @@ package com.fatboyindustrial.gsonjodatime;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -71,5 +72,31 @@ public class DateTimeConverterTest
     final Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
 
     assertThat(gson.fromJson((String) null, DateTime.class), is(nullValue()));
+  }
+
+  /**
+   * Tests that deserialising an ISO 8601 string with a milliseconds value works
+   */
+  @Test
+  public void testDeserializeWithMilliseconds() {
+    final Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
+    final String str = "\"2016-07-01T12:30:25.0Z\"";
+    final DateTime expected = new DateTime(2016, 7, 1, 12, 30, 25,
+                                           DateTimeZone.UTC).withZone(DateTimeZone.getDefault());
+
+    assertThat(gson.fromJson(str, DateTime.class), is(expected));
+  }
+
+  /**
+   * Tests that deserialising an ISO 8601 string without a milliseconds value works
+   */
+  @Test
+  public void testDeserializeWithoutMilliseconds() {
+    final Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
+    final String str = "\"2016-07-01T12:30:25Z\"";
+    final DateTime expected = new DateTime(2016, 7, 1, 12, 30, 25,
+                                           DateTimeZone.UTC).withZone(DateTimeZone.getDefault());
+
+    assertThat(gson.fromJson(str, DateTime.class), is(expected));
   }
 }


### PR DESCRIPTION
Fixes Issue #34.