### PR TITLE
[BUGFIX] Correctly deserialize ISO 8601 string with timezone offset

### DIFF
--- a/src/main/java/com/fatboyindustrial/gsonjodatime/DateTimeConverter.java
+++ b/src/main/java/com/fatboyindustrial/gsonjodatime/DateTimeConverter.java
@@ -87,7 +87,7 @@ public class DateTimeConverter implements JsonSerializer<DateTime>, JsonDeserial
       return null;
     }
 
-    final DateTimeFormatter fmt = ISODateTimeFormat.dateTimeParser();
+    final DateTimeFormatter fmt = ISODateTimeFormat.dateTimeParser().withOffsetParsed();
     return fmt.parseDateTime(json.getAsString());
   }
 }

--- a/src/test/java/com/fatboyindustrial/gsonjodatime/DateTimeConverterTest.java
+++ b/src/test/java/com/fatboyindustrial/gsonjodatime/DateTimeConverterTest.java
@@ -101,4 +101,17 @@ public class DateTimeConverterTest
 
     assertThat(gson.fromJson(str, DateTime.class), is(expected));
   }
+
+  /**
+   * Tests that deserialising an ISO 8601 string with a timezone offset works
+   */
+  @Test
+  public void testDeserializeWithTimezoneOffset()
+  {
+    final Gson gson = Converters.registerDateTime(new GsonBuilder()).create();
+    final String str = "2019-01-31T10:37:20.631+01:00";
+    final String json = "\"" + str + "\"";
+
+    assertThat(gson.fromJson(json, DateTime.class).toString(), is(str));
+  }
 }


### PR DESCRIPTION
When unserializing a ISO 8601 string with timezone offset like `2019-01-31T10:37:20.631+01:00` using the `DateTimeConverter` it currently gets converted to UTC `2019-01-31T09:37:20.631Z`. In order to re-instatiate the DateTime object as it was passed to Gson the offset has to be parsed.